### PR TITLE
Fix menus layout include

### DIFF
--- a/admin/menus.php
+++ b/admin/menus.php
@@ -4,7 +4,6 @@
  **********************************************/
 define('PROJECT_ROOT', '/var/www/html/spgp/');
 require_once PROJECT_ROOT . 'config/database.php';
-require_once PROJECT_ROOT . 'includes/layout.php';
 
 try {
     $pdo = getDbConnection();


### PR DESCRIPTION
## Summary
- remove redundant layout include at top of `admin/menus.php`

## Testing
- `php admin/menus.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fef3e9d988322a03eac68dcc05934